### PR TITLE
Set up development environment (AGENTS.md + Node 10 run instructions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a small **Tableau Extensions API "write-back" sample** (originally hosted on Glitch).
+`server.js` is an Express server that renders `views/index.ejs` (the extension UI, meant to be
+embedded inside a Tableau dashboard). `database.js` writes selected rows back to a Google Sheet
+using the service-account creds in `client_secret.json`.
+
+### Must run on Node 10
+`package.json` declares `"engines": { "node": "10.x" }` and the app genuinely depends on Node 10
+behavior. `database.js` calls `accessSpreadsheet2()` at module-load time (bottom of the file),
+which authenticates to Google. The bundled demo service-account creds are expired, so this auth
+**always fails** and produces an unhandled promise rejection. On Node 15+ (including the default
+Node 22) that rejection is **fatal and crashes the server on startup**. On Node 10 it is only a
+warning, so the Express server stays up and serves the page. Run with Node 10.
+
+### Gotcha: the default `node` is a Node 22 shim
+`/exec-daemon/node` (Node 22) sits at the front of `PATH` and shadows nvm's node even after
+`nvm use 10`. To actually run with Node 10, prepend the Node 10 bin dir to `PATH` for the command:
+
+```bash
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 10 >/dev/null
+export PATH="$(dirname "$(nvm which 10)"):$PATH"   # ensures `node` == Node 10, not the shim
+node --version   # should print v10.x
+```
+
+### Run the app
+`PORT` is **required** — `server.js` calls `app.listen(process.env.PORT)` and `npm start` does not
+set it. Run directly:
+
+```bash
+PORT=3000 node server.js
+# -> "Your app is listening on port 3000"; GET http://localhost:3000/ returns the extension UI
+```
+
+The standalone server only renders the extension UI. The `/update/` POST route and the Tableau JS
+in `public/index.js` require a live Tableau dashboard host plus valid Google Sheets creds, neither
+of which is available here, so end-to-end write-back cannot be exercised outside Tableau.
+
+### Lint / test
+There is no lint config and no test suite (only the `start` script in `package.json`). Nothing to
+run for lint or test.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the local development environment for this Tableau Extensions API "write-back" sample (an Express app that renders the extension UI in `views/index.ejs` and writes back to a Google Sheet via `database.js`).

- Adds `AGENTS.md` with durable Cursor Cloud instructions capturing the non-obvious gotchas needed to run the app.

No application code was modified.

## Key environment findings

- **Must run on Node 10** (`package.json` declares `engines.node = "10.x"`). `database.js` calls `accessSpreadsheet2()` at module-load time, which authenticates to Google with the bundled (expired) demo service-account creds and always fails. On Node 15+ (the default Node 22) the resulting unhandled promise rejection crashes the server on startup; on Node 10 it is only a warning, so the server stays up.
- The default `node` is a Node 22 shim (`/exec-daemon/node`) that shadows nvm even after `nvm use 10`; prepend the Node 10 bin dir to `PATH` to actually run on Node 10.
- `PORT` is required (`server.js` uses `process.env.PORT`; `npm start` doesn't set it). Run with `PORT=3000 node server.js`.
- No lint config and no test suite exist (only the `start` script).

## Walkthrough

Server running on Node 10 serving the extension UI, and the form accepting input:

[tableau_writeback_extension_demo.mp4](https://cursor.com/agents/bc-c573cf88-2b40-443e-8e9f-a12dc82a6b0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftableau_writeback_extension_demo.mp4)

[Extension page loaded](https://cursor.com/agents/bc-c573cf88-2b40-443e-8e9f-a12dc82a6b0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextension_page_loaded.webp)
[Cluster value entered](https://cursor.com/agents/bc-c573cf88-2b40-443e-8e9f-a12dc82a6b0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextension_value_entered.webp)

## Testing

- `PORT=3000 node server.js` (Node 10) → server listens and `GET /` returns HTTP 200 with the rendered extension UI.
- Manual GUI test: page loads in Chrome and the cluster-value form accepts input (see walkthrough).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c573cf88-2b40-443e-8e9f-a12dc82a6b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c573cf88-2b40-443e-8e9f-a12dc82a6b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

